### PR TITLE
[FIX] Fix filter_events uri parameter order

### DIFF
--- a/dfir_iris_client/case.py
+++ b/dfir_iris_client/case.py
@@ -1278,7 +1278,7 @@ class Case(object):
         filter_str = {} if filter_str is None else filter_str
         filter_uri = urllib.parse.quote(json.dumps(filter_str))
 
-        return self._s.pi_get(f'case/timeline/advanced-filter?q={filter_uri}&', cid=cid)
+        return self._s.pi_get(f'case/timeline/advanced-filter?cid={cid}&q={filter_uri}')
 
     def add_event(self, title: str, date_time: datetime.datetime, content: str = None, raw_content: str = None,
                   source: str = None, linked_assets: list = None, linked_iocs: list = None,


### PR DESCRIPTION
The way the `filter_events` function calls `pi_get` (`return self._s.pi_get(f'case/timeline/advanced-filter?q={filter_uri}&', cid=cid)`) leads to the `q` parameter being placed before the `cid` parameter.
One would not expect this to be a problem, but it is, as the API seems to expect the URI-parameters the other way around. This leads to the strange behavior of the API returning data from some other case id. (The last successfully accessed one? Maybe a caching problem / bug in iris-web? Unfortunately, I was not able to identify the root cause yet.)

However, this PR fixes the URI parameter order for the `filter_events` function to make it work for now.